### PR TITLE
Remover parsing manual da data no cadastro do usuário

### DIFF
--- a/backend/src/middlewares/validators/UserValidator.js
+++ b/backend/src/middlewares/validators/UserValidator.js
@@ -28,7 +28,7 @@ class UserValidator {
             check('data_nascimento')
                 .notEmpty()
                 .withMessage("Campo 'Data de nascimento' é obrigatório")
-                .isDate({ format: 'DD-MM-YYYY' })
+                .isDate({ format: 'YYYY-MM-DD' })
                 .withMessage("Formato de data inválido"),
 
             check('email')

--- a/backend/src/services/UserService.js
+++ b/backend/src/services/UserService.js
@@ -9,13 +9,11 @@ class UserService {
     async createUser(usuario) {
         const hashCode = await this.#hashPassword.hashPassword(usuario.senha)
 
-        let datearray = usuario.data_nascimento.split("/");
-        usuario.data_nascimento = datearray[1] + '/' + datearray[0] + '/' + datearray[2];
         const [{ identificador }] = await knex('apk.usuario').insert({
             nome: usuario.nome,
             participacao_atletica: usuario.participacao_atletica,
             celular: usuario.celular,
-            datadenascimento: usuario.data_nascimento,
+            datadenascimento: new Date(usuario.data_nascimento),
             e_mail: usuario.email,
             senha: hashCode
 


### PR DESCRIPTION
# Breve descrição da feature implementada
O objeto Date do Javascript consegue realizar o parse de um string de data, não é necessário realizar o split da string de data. Ademais, essa modificação segue o padrão de data retornado ao converter uma data para string (yyyy-mm-dd), substituindo o formato dd/mm/yyyy.

# Procedimentos necessários para testar a feature
1. Crie um usuário através da API ou do aplicativo.
2. Verifique que a conta foi criada corretamente.

# Verificações
- [X] Revisor adicionado ao pull request.
- [ ] Atividade movida para categoria "Revisão" no Trello.
- [X] Alteração testada localmente.