### PR TITLE
Adicionando campo 'favorito' no retorno da rota de listagem de eventos (feed)

### DIFF
--- a/backend/src/controllers/EventController.js
+++ b/backend/src/controllers/EventController.js
@@ -38,7 +38,7 @@ class EventController {
         try {
 
             const e = req.body
-            const result = await EventController.#eventService.create(e)
+            const result = await EventController.#eventService.create(e, req.email)
 
             if (result)
                 return res.status(200).json({ created: true }).send()

--- a/backend/src/controllers/EventController.js
+++ b/backend/src/controllers/EventController.js
@@ -1,6 +1,7 @@
 
 class EventController {
     static #eventService = require('../services/EventService')
+    static #userService = require('../services/UserService')
 
     constructor() {
     }
@@ -26,7 +27,27 @@ class EventController {
                 page = 1
             }
 
-            const eventList = await EventController.#eventService.search(filters, page)
+            const eventList = await EventController.#eventService.search(filters, page, req.email)
+
+            const promises = [];
+
+            eventList.forEach((event) => {
+                const promise = new Promise((resolve, reject) => {
+                    EventController.#userService.checkFavorite(req.email, event.idevento)
+                        .then(favorito => {
+                            event.favorito = favorito
+                            resolve(event)
+                        })
+                        .catch(e => {
+                            reject(e)
+                        })
+                })
+
+                promises.push(promise)
+            });
+
+            await Promise.all(promises).then(r => r).catch(error => { throw error })
+
             return res.status(200).json({ eventList }).send()
 
         } catch (error) {

--- a/backend/src/controllers/UserController.js
+++ b/backend/src/controllers/UserController.js
@@ -47,11 +47,7 @@ class UserController {
 
             const events = await UserController.#userService.getFavoriteEvents(identificador)
 
-            if (events.length > 0)
-                return res.status(200).json({ eventList: events }).send()
-            else
-                return res.status(200).json({ msg: 'Nenhum evento favoritado' }).send()
-
+            return res.status(200).json({ eventList: events }).send()
 
         } catch (error) {
             next(error)

--- a/backend/src/controllers/UserController.js
+++ b/backend/src/controllers/UserController.js
@@ -38,6 +38,25 @@ class UserController {
             next(error)
         }
     }
+
+    async getFavorites(req, res, next) {
+        try {
+            const email = req.email
+
+            const [{ identificador }] = await UserController.#userService.getUserByEmail(email)
+
+            const events = await UserController.#userService.getFavoriteEvents(identificador)
+
+            if (events.length > 0)
+                return res.status(200).json({ eventList: events }).send()
+            else
+                return res.status(200).json({ msg: 'Nenhum evento favoritado' }).send()
+
+
+        } catch (error) {
+            next(error)
+        }
+    }
 }
 
 module.exports = new UserController()

--- a/backend/src/middlewares/validators/EventValidator.js
+++ b/backend/src/middlewares/validators/EventValidator.js
@@ -46,12 +46,6 @@ class EventValidator {
                 .isInt({ min: 1 })
                 .withMessage("Campo 'Número de tickets' deve ser um numero inteiro maior do que 0"),
 
-            check('email_organizador')
-                .notEmpty()
-                .withMessage("Campo 'Email do organizador' é obrigatório")
-                .isEmail()
-                .withMessage("Email inválido"),
-
             check('preco_ingresso')
                 .notEmpty()
                 .withMessage("Campo 'Preço do ingresso' é obrigatório")

--- a/backend/src/middlewares/validators/UserValidator.js
+++ b/backend/src/middlewares/validators/UserValidator.js
@@ -28,7 +28,7 @@ class UserValidator {
             check('data_nascimento')
                 .notEmpty()
                 .withMessage("Campo 'Data de nascimento' é obrigatório")
-                .isDate({ format: 'DD-MM-YYYY' })
+                .isDate({ format: 'YYYY-MM-DD' })
                 .withMessage("Formato de data inválido"),
 
             check('email')

--- a/backend/src/server/routes.js
+++ b/backend/src/server/routes.js
@@ -24,6 +24,7 @@ class Routes {
             .get('/evento', this.#jwtAuth.verifyJWT(), this.#eventController.searchForEvents)
             .post('/evento', this.#jwtAuth.verifyJWT(), this.#eventValidator.getEventValidator(),
                 this.#eventController.createEvent)
+            .get('/favorito', this.#jwtAuth.verifyJWT(), this.#userController.getFavorites)
     }
 
     getRoutes() {

--- a/backend/src/services/EventService.js
+++ b/backend/src/services/EventService.js
@@ -24,10 +24,10 @@ class EventService {
         return eventList
     }
 
-    async create(event) {
+    async create(event, emailOrganizador) {
 
         const e = new Event(event.nome, event.cidade, event.endereco, event.data_inicio,
-            event.data_fim, event.n_tickets, event.email_organizador, event.preco_ingresso,
+            event.data_fim, event.n_tickets, emailOrganizador, event.preco_ingresso,
             event.url_imagem_banner, event.descricao_do_evento
         )
 

--- a/backend/src/services/UserService.js
+++ b/backend/src/services/UserService.js
@@ -40,6 +40,16 @@ class UserService {
             .join('apk.evento', 'apk.favorita.evento_id', 'apk.evento.idevento')
             .select('*').where({ 'apk.favorita.usuario_id': usuario_id })
     }
+
+    async checkFavorite(email, id_evento) {
+
+        const [{ identificador }] = await this.getUserByEmail(email)
+
+        const data = await knex('apk.favorita').where({ usuario_id: identificador, evento_id: id_evento })
+
+        return data.length > 0 ? true : false
+    }
+
 }
 
 module.exports = new UserService()

--- a/backend/src/services/UserService.js
+++ b/backend/src/services/UserService.js
@@ -30,6 +30,16 @@ class UserService {
     async authUser(usuario) {
         return await this.#hashPassword.verifyPassword(usuario)
     }
+
+    async getUserByEmail(email) {
+        return await knex('apk.usuario').select('identificador', 'nome').where({ e_mail: email });
+    }
+
+    async getFavoriteEvents(usuario_id) {
+        return await knex('apk.favorita')
+            .join('apk.evento', 'apk.favorita.evento_id', 'apk.evento.idevento')
+            .select('*').where({ 'apk.favorita.usuario_id': usuario_id })
+    }
 }
 
 module.exports = new UserService()

--- a/backend/src/services/UserService.js
+++ b/backend/src/services/UserService.js
@@ -9,13 +9,11 @@ class UserService {
     async createUser(usuario) {
         const hashCode = await this.#hashPassword.hashPassword(usuario.senha)
 
-        let datearray = usuario.data_nascimento.split("/");
-        usuario.data_nascimento = datearray[1] + '/' + datearray[0] + '/' + datearray[2];
         const [{ identificador }] = await knex('apk.usuario').insert({
             nome: usuario.nome,
             participacao_atletica: usuario.participacao_atletica,
             celular: usuario.celular,
-            datadenascimento: usuario.data_nascimento,
+            datadenascimento: new Date(usuario.data_nascimento),
             e_mail: usuario.email,
             senha: hashCode
 


### PR DESCRIPTION
# Breve descrição da feature implementada
Adicionado o campo 'favorito' no JSON retornado pela rota GET '/evento' que informa se um usuário favoritou determinado evento ou não.

# Procedimentos necessários para testar a feature
1. Seguir passos do PR #17 
2. Logar com um usuário no sistema enviando uma requisição POST para a rota '/login' com o seguinte corpo e salvar o token jwt retornado
```JSON
{
	"email": "org@gmail.com",
	"senha": "senha123"
}
```
3. Criar um evento enviando uma requisição POST para a rota '/evento' (passando o token jwt no header) com o seguinte corpo
```JSON
{
	"nome": "Evento teste",
	"cidade": "londrina",
	"endereco": "rua teste",
	"data_inicio": "2022-05-22T13:00:00.000Z",
	"data_fim": "2022-06-22T13:00:00.000Z",
	"n_tickets": "1",
	"preco_ingresso": "10.00",
	"url_imagem_banner": "https://i.pinimg.com/originals/4c/6d/f9/4c6df95f02a071086571d91c3668043d.jpg",
	"descricao_do_evento": "Um evento bacana"
	
}
```
4. Enviar uma requisição GET para a rota '/evento' (passando o token jwt no header), verificando quais são os eventos favoritados pelo usuário
```
http://localhost:3333/evento
```

# Verificações
- [x] Revisor adicionado ao pull request.
- [ ] Atividade movida para categoria "Revisão" no Trello.
- [x] Alteração testada localmente.
